### PR TITLE
Add support for contextName

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildStep.java
@@ -45,6 +45,9 @@ public class KubectlBuildStep extends Step {
     @DataBoundSetter
     public String caCertificate;
 
+    @DataBoundSetter
+    public String contextName;
+
     @DataBoundConstructor
     public KubectlBuildStep() {
     }
@@ -73,6 +76,7 @@ public class KubectlBuildStep extends Step {
                     step.serverUrl,
                     step.credentialsId,
                     step.caCertificate,
+                    step.contextName,
                     getContext());
 
             // Write config

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/KubectlBuildWrapper.java
@@ -45,6 +45,9 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
     @DataBoundSetter
     public String caCertificate;
 
+    @DataBoundSetter
+    public String contextName;
+
     @DataBoundConstructor
     public KubectlBuildWrapper() {
     }
@@ -59,6 +62,7 @@ public class KubectlBuildWrapper extends SimpleBuildWrapper {
                 this.serverUrl,
                 this.credentialsId,
                 this.caCertificate,
+                this.contextName,
                 workspace,
                 launcher,
                 build);

--- a/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/kubernetes/cli/kubeconfig/KubeConfigWriterFactory.java
@@ -13,15 +13,15 @@ import java.io.IOException;
  */
 public abstract class KubeConfigWriterFactory {
     public static KubeConfigWriter get(@Nonnull String serverUrl, @Nonnull String credentialsId,
-                                       @Nonnull String caCertificate, FilePath workspace, Launcher launcher, Run<?, ?> build) {
-        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, workspace, launcher, build);
+                                       @Nonnull String caCertificate, @Nonnull String contextName, FilePath workspace, Launcher launcher, Run<?, ?> build) {
+        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, contextName, workspace, launcher, build);
     }
 
     public static KubeConfigWriter get(@Nonnull String serverUrl, @Nonnull String credentialsId,
-                                       @Nonnull String caCertificate, StepContext context) throws IOException, InterruptedException {
+                                       @Nonnull String caCertificate, @Nonnull String contextName, StepContext context) throws IOException, InterruptedException {
         Run<?, ?> run = context.get(Run.class);
         FilePath workspace = context.get(FilePath.class);
         Launcher launcher = context.get(Launcher.class);
-        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, workspace, launcher, run);
+        return new KubeConfigWriter(serverUrl, credentialsId, caCertificate, contextName, workspace, launcher, run);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/KubectlIntegrationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/KubectlIntegrationTest.java
@@ -97,7 +97,44 @@ public class KubectlIntegrationTest extends KubectlTestBase {
         FilePath configDump = r.jenkins.getWorkspaceFor(p).child("configDump");
         assertTrue(configDump.exists());
         String configDumpContent = configDump.readToString().trim();
-        assertEquals("---\napiVersion: v1\nclusters:\n- cluster:\n  name: test-sample", configDumpContent);
+        assertEquals("---\n" +
+                "apiVersion: v1\n" +
+                "contexts:\n" +
+                "- context:\n" +
+                "  name: test-sample\n" +
+                "- context:\n" +
+                "  name: k8s\n" +
+                "current-context: minikube", configDumpContent);
+    }
+
+    @Test
+    public void testFileCredentialsWithContext() throws Exception {
+        CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), fileCredential());
+
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "fileCredential");
+        p.setDefinition(new CpsFlowDefinition(loadResource("kubectlRawWithContext.groovy"), true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        assertNotNull(b);
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+
+        FilePath configDump = r.jenkins.getWorkspaceFor(p).child("configDump");
+        assertTrue(configDump.exists());
+        String configDumpContent = configDump.readToString().trim();
+        assertEquals("apiVersion: v1\n" +
+                "clusters: []\n" +
+                "contexts:\n" +
+                "- context:\n" +
+                "    cluster: \"\"\n" +
+                "    user: \"\"\n" +
+                "  name: k8s\n" +
+                "- context:\n" +
+                "    cluster: \"\"\n" +
+                "    user: \"\"\n" +
+                "  name: test-sample\n" +
+                "current-context: test-sample\n" +
+                "kind: Config\n" +
+                "preferences: {}\n" +
+                "users: []", configDumpContent);
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/KubectlTestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/kubernetes/credentials/KubectlTestBase.java
@@ -107,6 +107,17 @@ public class KubectlTestBase {
     }
 
     protected FileCredentials fileCredential() throws UnsupportedEncodingException {
-        return new FileCredentialsImpl(CredentialsScope.GLOBAL, CREDENTIAL_ID, "sample", "file-name", SecretBytes.fromBytes("---\napiVersion: v1\nclusters:\n- cluster:\n  name: test-sample\n".getBytes("UTF-8")));
+        return new FileCredentialsImpl(CredentialsScope.GLOBAL,
+                CREDENTIAL_ID,
+                "sample",
+                "file-name",
+                SecretBytes.fromBytes(("---\n" +
+                        "apiVersion: v1\n" +
+                        "contexts:\n" +
+                        "- context:\n" +
+                        "  name: test-sample\n" +
+                        "- context:\n" +
+                        "  name: k8s\n" +
+                        "current-context: minikube\n").getBytes("UTF-8")));
     }
 }

--- a/src/test/resources/org/jenkinsci/plugins/kubernetes/credentials/kubectlRawWithContext.groovy
+++ b/src/test/resources/org/jenkinsci/plugins/kubernetes/credentials/kubectlRawWithContext.groovy
@@ -1,0 +1,7 @@
+node{
+  stage('Run') {
+    withKubeConfig([credentialsId: 'cred1234', contextName: 'test-sample']) {
+      sh 'cat "$KUBECONFIG" > configDump'
+    }
+  }
+}


### PR DESCRIPTION
Allow to specify the context to be used to configure `kubectl`